### PR TITLE
add --compatibility for createrepo

### DIFF
--- a/dockerfiles/dockerfile-new-image
+++ b/dockerfiles/dockerfile-new-image
@@ -44,7 +44,7 @@ RUN if [ "${RPMS}" ]; then \
     tdnf install -y createrepo; \
     cp -r /WORKDIR/RPMS ${LOCAL_REPO_PATH}; \
     cp /WORKDIR/REPO/local.repo /etc/yum.repos.d/local.repo; \
-    createrepo --database ${LOCAL_REPO_PATH} --workers 10; \
+    createrepo --compatibility --database ${LOCAL_REPO_PATH} --workers 10; \
     tdnf makecache; \
     tdnf autoremove -y createrepo; \
 fi


### PR DESCRIPTION
`--compatibility` flag is needed when using `createrepo` to avoid getting `Error: Failed to synchronize cache for repo 'Azure Linux Local Repo'`